### PR TITLE
load model by filename instead of path

### DIFF
--- a/yeastcells/model.py
+++ b/yeastcells/model.py
@@ -5,13 +5,14 @@ from detectron2 import model_zoo
 from detectron2.engine import DefaultPredictor
 from detectron2.config import get_cfg
 
-def load_model(model_path, seg_thresh=0.94, device='cpu'):
+def load_model(model_filename, seg_thresh=0.94, device='cpu'):
     '''
     Load and configure the Mask-RCNN model.
     Parameters
     ----------
-    model_path : str
-        Path to model file containing weights.
+    model_filename : str
+        Path to model file containing weights, usually thisfilename
+        ends with .pth .
     seg_thresh : float, optional
         Set the segmentation threshold score for the model to assign a 
         pixel to a cell region using the probability outcomes of 
@@ -31,7 +32,7 @@ def load_model(model_path, seg_thresh=0.94, device='cpu'):
     cfg.merge_from_file(model_zoo.get_config_file(
         "COCO-InstanceSegmentation/mask_rcnn_R_50_FPN_3x.yaml"))
     cfg.MODEL.ROI_HEADS.NUM_CLASSES = 1
-    cfg.MODEL.WEIGHTS = f'{model_path}/model_final.pth'
+    cfg.MODEL.WEIGHTS = model_filename
     cfg.MODEL.ROI_HEADS.SCORE_THRESH_TEST = seg_thresh
     cfg.MODEL.ROI_HEADS.BATCH_SIZE_PER_IMAGE = 512
     cfg.MODEL.DEVICE=device


### PR DESCRIPTION
I would suggest to pass the filename of the model, rather than path and assume the filename. One might opt to load a checkpoint rather than the final model.

Not sure how much this affects the notebooks and code base.